### PR TITLE
A recipient is now required when sending a message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+/database/seeds

--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -20,26 +20,26 @@ class MessageController extends Controller
     public function index()
     {
         $title = "Inbox";
-        $messages = \Auth::user()->received()->get();
+        $messages = \Auth::user()->received()->orderBy('id', 'desc')->get();
         return view('messages.to', compact('messages', 'title'));
     }
 
     public function starred() {
         $title = "Starred";
-        $messages = \Auth::user()->starred()->get();
+        $messages = \Auth::user()->starred()->orderBy('id', 'desc')->get();
         return view('messages.to', compact('messages', 'title'));
     }
 
     public function trash() {
         $title = "Trash";
-        $inboxTrash = \Auth::user()->inboxTrash()->get();
-        $sentTrash = \Auth::user()->sentTrash()->get();
+        $inboxTrash = \Auth::user()->inboxTrash()->orderBy('id', 'desc')->get();
+        $sentTrash = \Auth::user()->sentTrash()->orderBy('id', 'desc')->get();
         return view('messages.trash', compact('inboxTrash', 'sentTrash', 'title'));
     }
 
     public function sent() {
         $title = "Sent";
-        $messages = \Auth::user()->sent()->get();
+        $messages = \Auth::user()->sent()->orderBy('id', 'desc')->get();
         foreach ($messages as $message) {
             $message->link = '/messages/' . $message->id; 
         }
@@ -48,7 +48,7 @@ class MessageController extends Controller
 
     public function drafts() {
         $title = "Drafts";
-        $messages = \Auth::user()->drafts()->get();
+        $messages = \Auth::user()->drafts()->orderBy('id', 'desc')->get();
         foreach ($messages as $message) {
             $message->link = '/messages/' . $message->id . '/edit'; 
         }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(UserSeeder::class);
+        $this->call(MessageSeeder::class);
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+   
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,7 +11,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $this->call(UserSeeder::class);
-        $this->call(MessageSeeder::class);
+        // $this->call(UserSeeder::class);
+        // $this->call(MessageSeeder::class);
     }
 }


### PR DESCRIPTION
When a user clicks Save or Send without selecting any recipients in their new message, a tooltip pops up saying that you must select an item in the list and will not send or save without anything selected.