### PR TITLE
form validation for recipients being required on a new message

### DIFF
--- a/resources/views/messages/create.blade.php
+++ b/resources/views/messages/create.blade.php
@@ -15,7 +15,7 @@
     <div class="form-group">
       <label for="recipients" class="col-sm-2 control-label">Recipients</label>
       <div class="col-sm-10">
-        <select multiple name="recipients[]" class="form-control">
+        <select multiple name="recipients[]" class="form-control" required>
 
 @foreach ($recipients as $recipient)          
           <option value={{ $recipient->id }}>{{ $recipient->name }}</option>


### PR DESCRIPTION
When a user tries to Send or Save a new message without selecting any recipients, a tooltip pops up saying that they must select an item in the list and does not do the save or send action until that is done.