### PR TITLE
Resolved - Undo/Trash Can Icon Issue #46

### DIFF
--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -21,6 +21,7 @@ class MessageController extends Controller
     {
         $title = "Inbox";
         $messages = \Auth::user()->received()->orderBy('id', 'desc')->get();
+       
         return view('messages.to', compact('messages', 'title'));
     }
 

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -12,7 +12,7 @@
       <button class="btn btn-xs btn-default">
         @if ($authorizedMessage->pivot->deleted_at != null)
           <i class="fa fa-undo" aria-hidden="true"></i>
-        @elseif($message->is_deleted == true)
+        @elseif($message->is_deleted == true &&  $authorizedMessage->pivot->deleted_at != null)
           <i class="fa fa-undo" aria-hidden="true"></i>
         @else
           <i class="fa fa-trash" aria-hidden="true"></i>

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -14,6 +14,8 @@
           <i class="fa fa-undo" aria-hidden="true"></i>
         @elseif($message->is_deleted == true &&  $authorizedMessage->pivot->deleted_at != null)
           <i class="fa fa-undo" aria-hidden="true"></i>
+        @elseif ($message->is_deleted == true && $message->sender_id == \Auth::user()->id)  
+          <i class="fa fa-undo" aria-hidden="true"></i>
         @else
           <i class="fa fa-trash" aria-hidden="true"></i>
         @endif


### PR DESCRIPTION
fixed bug:

Per Melo's Comment on our pull request -->

Found an issue:

I am on a group message and I delete the message from my inbox
Somebody else clicks on that group message from their inbox
The delete button on their message has the undo icon instead of the trash can icon
The button still deletes, but the wrong icon is showing